### PR TITLE
Fix typos and markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # WalEx
 
-Postgres [Change Data Capture (CDC)](https://en.wikipedia.org/wiki/Change_data_capture) in Elixir.
+Postgres [Change Data Capture
+(CDC)](https://en.wikipedia.org/wiki/Change_data_capture) in Elixir.
 
-WalEx allows you to listen to change events on your Postgres tables then perform callback-like actions with the data. For example:
+WalEx allows you to listen to change events on your Postgres tables then
+perform callback-like actions with the data. For example:
 
 - Stream database changes to an external data processing service
 - Send a user a welcome email after they create a new account
@@ -12,9 +14,11 @@ WalEx allows you to listen to change events on your Postgres tables then perform
 
 You can learn more about CDC and what you can do with it here: [Why capture changes?](https://bbhoss.io/posts/announcing-cainophile/#why-capture-changes)
 
-### Credit
+## Credit
 
-This library steals liberally from [realtime](https://github.com/supabase/realtime) from Supabase, which in turn draws heavily on [cainophile](https://github.com/cainophile/cainophile).
+This library steals liberally from
+[realtime](https://github.com/supabase/realtime) from Supabase, which in turn
+draws heavily on [cainophile](https://github.com/cainophile/cainophile).
 
 ## Installation
 
@@ -33,7 +37,8 @@ end
 
 ### Logical Replication
 
-WalEx only supports PostgreSQL. To get started, you first need to configure PostgreSQL for logical replication:
+WalEx only supports PostgreSQL. To get started, you first need to configure
+PostgreSQL for logical replication:
 
 ```sql
 ALTER SYSTEM SET wal_level = 'logical';
@@ -47,23 +52,33 @@ command: [ "postgres", "-c", "wal_level=logical" ]
 
 ### Publication
 
-When you change the `wal_level` variable, you'll need to restart your PostgreSQL server. Once you've restarted, go ahead and [create a publication](https://www.postgresql.org/docs/current/sql-createpublication.html) for the tables you want to receive changes for:
+When you change the `wal_level` variable, you'll need to restart your
+PostgreSQL server. Once you've restarted, go ahead and [create a
+publication](https://www.postgresql.org/docs/current/sql-createpublication.html)
+for the tables you want to receive changes for:
 
 All tables:
+
 ```sql
 CREATE PUBLICATION events FOR ALL TABLES;
 ```
 
 Specific tables:
+
 ```sql
 CREATE PUBLICATION events FOR TABLE user_account, todo;
 ```
 
 ### Replica Identity
 
-WalEx supports all of the settings for [REPLICA IDENTITY](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY). Use `FULL` if you can use it, as it will make tracking differences easier as the old data will be sent alongside the new data. You'll need to set this for each table.
+WalEx supports all of the settings for [REPLICA
+IDENTITY](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY).
+Use `FULL` if you can use it, as it will make tracking differences easier as
+the old data will be sent alongside the new data. You'll need to set this for
+each table.
 
 Specific tables:
+
 ```sql
 ALTER TABLE user_account REPLICA IDENTITY FULL;
 ALTER TABLE todo REPLICA IDENTITY FULL;
@@ -73,12 +88,13 @@ ALTER TABLE todo REPLICA IDENTITY FULL;
 
 Amazon (AWS) RDS Postgres allows you to configure logical replication.
 
-- https://debezium.io/documentation/reference/1.4/connectors/postgresql.html#setting-up-postgresql
-- https://dev.to/vumdao/how-to-change-rds-postgresql-configurations-2kmk
+- <https://debezium.io/documentation/reference/1.4/connectors/postgresql.html#setting-up-postgresql>
+- <https://dev.to/vumdao/how-to-change-rds-postgresql-configurations-2kmk>
 
-When creating a new Postgres database on RDS, you'll need to set a Paramater Group with the following settings:
+When creating a new Postgres database on RDS, you'll need to set a Parameter
+Group with the following settings:
 
-```
+```text
 rds.replication = 1
 max_replication_slots = 5
 max_slot_wal_keep_size = 2048
@@ -99,11 +115,13 @@ config :walex,
   db_port: "5432",
   db_ssl: true,
   db_ip_version: "ipv6",
-  # :temporary atom is also supported if you don't want Postgres keeping track of what you've acknowledged
+  # :temporary atom is also supported if you don't want Postgres keeping track
+  # of what you've acknowledged
   slot_name:  "example",
   max_replication_lag_in_mb: 0,
   publications: "[\"example\"]", # needs to be a json-decodable string
-  # specify the changes you want to subscribe to. If you exclude, it will subscribe to all change events
+  # specify the changes you want to subscribe to. If you exclude, it will
+  # subscribe to all change events
   subscriptions: [:user_account, :todo],
   # include your modules for processing events (supervised)
   modules: [ExampleApp.UserAcountEvent, ExampleApp.TodoEvent]
@@ -156,9 +174,12 @@ defmodule ExampleApp.UserAccountEvent do
 end
 ```
 
-Additional filter helpers available in the [WalEx.TransactionFilter](lib/walex/transaction_filter.ex) module.
+Additional filter helpers available in the
+[WalEx.TransactionFilter](lib/walex/transaction_filter.ex) module.
 
-The process_event returns an `Event` Struct with changes provided by the [map_diff](https://github.com/Qqwy/elixir-map_diff) library (UPDATE example where _name_ field was changed):
+The process_event returns an `Event` Struct with changes provided by the
+[map_diff](https://github.com/Qqwy/elixir-map_diff) library (UPDATE example
+where _name_ field was changed):
 
 ```elixir
 %Event{

--- a/lib/walex/decoder/oid_database.ex
+++ b/lib/walex/decoder/oid_database.ex
@@ -11,7 +11,7 @@
 #  Following query was used to generate this file:
 #  SELECT json_object_agg(UPPER(PT.typname), PT.oid::int4 ORDER BY pt.oid)
 #  FROM pg_type PT
-#  WHERE typnamespace = (SELECT pgn.oid FROM pg_namespace pgn WHERE nspname = 'pg_catalog') -- Take only builting Postgres types with stable OID (extension types are not guaranted to be stable)
+#  WHERE typnamespace = (SELECT pgn.oid FROM pg_namespace pgn WHERE nspname = 'pg_catalog') -- Take only built-in Postgres types with stable OID (extension types are not guaranteed to be stable)
 #  AND typtype = 'b' -- Only basic types
 #  AND typisdefined -- Ignore undefined types
 


### PR DESCRIPTION
Found via these commands:

    codespell . -L complies
    markdownlint *.md