### PR TITLE
feat: Accept multiple apps configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ defmodule MyApp.Application do
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [
-      {WalEx.Supervisor, Application.get_env(:walex, MyApp)}
+      {WalEx.Supervisor, Application.get_env(:my_app, WalEx)}
     ]
 
     opts = [strategy: :one_for_one, name: MyApp.Supervisor]
@@ -154,24 +154,24 @@ Example Module:
 
 ```elixir
 defmodule MyApp.UserAccountEvent do
-  import WalEx.{Event, TransactionFilter}
+  use WalEx.Event, name: MyApp
 
-  @behaviour WalEx.Event
+  import WalEx.TransactionFilter
 
   def process(txn) do
     cond do
       insert_event?(:user_account, txn) ->
-        {:ok, user_account} = event(:user_account, txn, MyApp)
+        {:ok, user_account} = event(:user_account, txn)
         IO.inspect(user_account_insert_event: user_account)
         # do something with user_account data
 
       update_event?(:user_account, txn) ->
-        {:ok, user_account} = event(:user_account, txn, MyApp)
+        {:ok, user_account} = event(:user_account, txn)
         IO.inspect(user_account_update_event: user_account)
 
       # you can also specify the relation
       delete_event?("public.user_account", txn) ->
-        {:ok, user_account} = event(:user_account, txn, MyApp)
+        {:ok, user_account} = event(:user_account, txn)
         IO.inspect(user_account_delete_event: user_account)
 
       true ->

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Config:
 ```elixir
 # config.exs
 
-config :walex, ExampleApp,
+config :my_app, WalEx,
   hostname: "localhost",
   username: "postgres",
   password: "postgres",
@@ -115,8 +115,8 @@ config :walex, ExampleApp,
   database: "postgres",
   publication: "events",
   subscriptions: [:user_account, :todo],
-  modules: [ExampleApp.UserAcountEvent, ExampleApp.TodoEvent],
-  name: ExampleApp
+  modules: [MyApp.UserAcountEvent, MyApp.TodoEvent],
+  name: MyApp
 ```
 
 It is also possible to just define the URL configuration for the database
@@ -124,27 +124,27 @@ It is also possible to just define the URL configuration for the database
 ```elixir
 # config.exs
 
-config :walex, ExampleApp,
+config :my_app, WalEx,
   url: "postgres://username:password@hostname:port/database"
   publication: "events",
   subscriptions: [:user_account, :todo],
-  modules: [ExampleApp.UserAcountEvent, ExampleApp.TodoEvent],
-  name: ExampleApp
+  modules: [MyApp.UserAcountEvent, MyApp.TodoEvent],
+  name: MyApp
 ```
 
 Supervisor:
 
 ```elixir
-defmodule ExampleApp.Application do
+defmodule MyApp.Application do
   use Application
 
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [
-      {WalEx.Supervisor, Application.get_env(:walex, ExampleApp)}
+      {WalEx.Supervisor, Application.get_env(:walex, MyApp)}
     ]
 
-    opts = [strategy: :one_for_one, name: ExampleApp.Supervisor]
+    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end
@@ -153,7 +153,7 @@ end
 Example Module:
 
 ```elixir
-defmodule ExampleApp.UserAccountEvent do
+defmodule MyApp.UserAccountEvent do
   import WalEx.{Event, TransactionFilter}
 
   @behaviour WalEx.Event
@@ -161,17 +161,17 @@ defmodule ExampleApp.UserAccountEvent do
   def process(txn) do
     cond do
       insert_event?(:user_account, txn) ->
-        {:ok, user_account} = event(:user_account, txn, ExampleApp)
+        {:ok, user_account} = event(:user_account, txn, MyApp)
         IO.inspect(user_account_insert_event: user_account)
         # do something with user_account data
 
       update_event?(:user_account, txn) ->
-        {:ok, user_account} = event(:user_account, txn, ExampleApp)
+        {:ok, user_account} = event(:user_account, txn, MyApp)
         IO.inspect(user_account_update_event: user_account)
 
       # you can also specify the relation
       delete_event?("public.user_account", txn) ->
-        {:ok, user_account} = event(:user_account, txn, ExampleApp)
+        {:ok, user_account} = event(:user_account, txn, MyApp)
         IO.inspect(user_account_delete_event: user_account)
 
       true ->

--- a/lib/walex/configs.ex
+++ b/lib/walex/configs.ex
@@ -1,0 +1,82 @@
+defmodule WalEx.Configs do
+  use Agent
+
+  def start_link(opts) do
+    configs =
+      opts
+      |> Keyword.get(:configs)
+      |> build_app_configs()
+
+    app_name = Keyword.get(configs, :name)
+
+    name = WalEx.Registry.set_name(:set_agent, __MODULE__, app_name)
+
+    Agent.start_link(fn -> configs end, name: name)
+  end
+
+  def get_configs(app_name, []) do
+    WalEx.Registry.get_state(:get_agent, __MODULE__, app_name)
+  end
+
+  def get_configs(app_name, keys) do
+    app_name
+    |> get_configs([])
+    |> Keyword.take(keys)
+  end
+
+  defp build_app_configs(configs) do
+    db_configs_from_url =
+      configs
+      |> Keyword.get(:url, "")
+      |> parse_url()
+
+    [
+      hostname: Keyword.get(configs, :hostname, db_configs_from_url[:hostname]),
+      username: Keyword.get(configs, :username, db_configs_from_url[:username]),
+      password: Keyword.get(configs, :password, db_configs_from_url[:password]),
+      port: Keyword.get(configs, :port, db_configs_from_url[:port]),
+      database: Keyword.get(configs, :database, db_configs_from_url[:database]),
+      subscriptions: Keyword.get(configs, :subscriptions),
+      publication: Keyword.get(configs, :publication),
+      modules: Keyword.get(configs, :modules),
+      name: Keyword.get(configs, :name)
+    ]
+  end
+
+  defp parse_url(""), do: []
+
+  defp parse_url(url) when is_binary(url) do
+    info = URI.parse(url)
+
+    if is_nil(info.host), do: raise("host is not present")
+
+    if is_nil(info.path) or not (info.path =~ ~r"^/([^/])+$"),
+      do: raise("path should be a database name")
+
+    destructure [username, password], info.userinfo && String.split(info.userinfo, ":")
+    "/" <> database = info.path
+
+    url_opts = set_url_opts(username, password, database, info)
+
+    for {k, v} <- url_opts,
+        not is_nil(v),
+        do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
+  end
+
+  defp set_url_opts(username, password, database, info) do
+    url_opts = [
+      username: username,
+      password: password,
+      database: database,
+      port: info.port
+    ]
+
+    put_hostname_if_present(url_opts, info.host)
+  end
+
+  defp put_hostname_if_present(keyword, ""), do: keyword
+
+  defp put_hostname_if_present(keyword, hostname) when is_binary(hostname) do
+    Keyword.put(keyword, :hostname, hostname)
+  end
+end

--- a/lib/walex/configs.ex
+++ b/lib/walex/configs.ex
@@ -14,14 +14,10 @@ defmodule WalEx.Configs do
     Agent.start_link(fn -> configs end, name: name)
   end
 
-  def get_configs(app_name, []) do
-    WalEx.Registry.get_state(:get_agent, __MODULE__, app_name)
-  end
+  def get_configs(app_name, keys \\ []) when is_list(keys) do
+    configs = WalEx.Registry.get_state(:get_agent, __MODULE__, app_name)
 
-  def get_configs(app_name, keys) do
-    app_name
-    |> get_configs([])
-    |> Keyword.take(keys)
+    if Enum.empty?(keys), do: configs, else: Keyword.take(configs, keys)
   end
 
   defp build_app_configs(configs) do

--- a/lib/walex/database_replication_supervisor.ex
+++ b/lib/walex/database_replication_supervisor.ex
@@ -1,13 +1,24 @@
 defmodule WalEx.DatabaseReplicationSupervisor do
   use Supervisor
 
-  def start_link(config) do
-    Supervisor.start_link(__MODULE__, config, name: __MODULE__)
+  alias WalEx.ReplicationServer
+
+  def start_link(opts) do
+    app_name = Keyword.get(opts, :app_name)
+
+    name = WalEx.Registry.set_name(:set_supervisor, __MODULE__, app_name)
+
+    Supervisor.start_link(__MODULE__, configs: opts, name: name)
   end
 
   @impl true
-  def init(config) do
-    children = [{WalEx.ReplicationServer, config}]
+  def init(opts) do
+    app_name =
+      opts
+      |> Keyword.get(:configs)
+      |> Keyword.get(:app_name)
+
+    children = [{ReplicationServer, app_name: app_name}]
 
     Supervisor.init(children, strategy: :one_for_all)
   end

--- a/lib/walex/event.ex
+++ b/lib/walex/event.ex
@@ -1,4 +1,9 @@
 defmodule WalEx.Event do
+  import WalEx.TransactionFilter
+
+  alias WalEx.Changes
+  alias WalEx.Event
+
   defstruct(
     table: nil,
     type: nil,
@@ -7,11 +12,6 @@ defmodule WalEx.Event do
     changes: nil,
     commit_timestamp: nil
   )
-
-  import WalEx.TransactionFilter
-
-  alias WalEx.Event
-  alias WalEx.Changes
 
   @doc """
   Behaviour for processing event
@@ -72,8 +72,8 @@ defmodule WalEx.Event do
   @doc """
   When single event per table is expected
   """
-  def event(table_name, txn) do
-    with true <- has_tables?(table_name, txn),
+  def event(table_name, txn, app_name) do
+    with true <- has_tables?(table_name, txn, app_name),
          [table] <- table(table_name, txn),
          casted_event <- cast(table),
          true <- Map.has_key?(casted_event, :__struct__) do
@@ -90,8 +90,8 @@ defmodule WalEx.Event do
   @doc """
   When multiple events per table is expected (transaction)
   """
-  def events(table_name, txn) do
-    with true <- has_tables?(table_name, txn),
+  def events(table_name, txn, app_name) do
+    with true <- has_tables?(table_name, txn, app_name),
          tables <- table(table_name, txn),
          casted_events <- Enum.map(tables, &cast(&1)) do
       {:ok, casted_events}

--- a/lib/walex/event.ex
+++ b/lib/walex/event.ex
@@ -18,6 +18,17 @@ defmodule WalEx.Event do
   """
   @callback process(payload :: %Changes.Transaction{}) :: :ok | {:error, any()}
 
+  defmacro __using__(opts) do
+    app_name = Keyword.get(opts, :name)
+
+    quote do
+      @behaviour Event
+
+      def event(table_name, txn), do: Event.event(table_name, txn, unquote(app_name))
+      def events(table_name, txn), do: Event.events(table_name, txn, unquote(app_name))
+    end
+  end
+
   def cast(%Changes.NewRecord{
         table: table,
         type: "INSERT",

--- a/lib/walex/events.ex
+++ b/lib/walex/events.ex
@@ -1,30 +1,33 @@
 defmodule WalEx.Events do
   use GenServer
 
-  def start_link(process_event) do
-    GenServer.start_link(__MODULE__, process_event, name: __MODULE__)
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
-  def process(txn) do
-    GenServer.call(__MODULE__, {:process, txn}, :infinity)
-  end
-
-  @impl true
-  def init(state) do
-    {:ok, state}
+  def process(txn, server) do
+    GenServer.call(__MODULE__, {:process, txn, server}, :infinity)
   end
 
   @impl true
-  def handle_call({:process, txn}, _from, state) do
-    process_events(state, txn)
+  def init(%{}) do
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:process, txn, server}, _from, state) do
+    server
+    |> WalEx.Configs.get_configs([:modules])
+    |> process_events(txn)
+
     {:reply, :ok, state}
   end
 
-  defp process_events([module: modules], txn) when is_list(modules) do
-    Enum.each(modules, fn module -> apply(module, :process, [txn]) end)
+  defp process_events([modules: modules], txn) when is_list(modules) do
+    Enum.each(modules, fn module -> module.process(txn) end)
   end
 
-  defp process_events([module: module], txn), do: apply(module, :process, [txn])
+  defp process_events([modules: module], txn), do: module.process(txn)
 
   defp process_events(nil, %{changes: [], commit_timestamp: _}), do: nil
 end

--- a/lib/walex/events.ex
+++ b/lib/walex/events.ex
@@ -10,7 +10,7 @@ defmodule WalEx.Events do
   end
 
   @impl true
-  def init(%{}) do
+  def init(_) do
     {:ok, %{}}
   end
 

--- a/lib/walex/registry.ex
+++ b/lib/walex/registry.ex
@@ -1,0 +1,22 @@
+defmodule WalEx.Registry do
+  @walex_registry :walex_registry
+
+  def start_registry do
+    case Process.whereis(@walex_registry) do
+      nil -> Registry.start_link(keys: :unique, name: @walex_registry)
+      pid -> {:ok, pid}
+    end
+  end
+
+  def set_name(:set_agent, module, app_name), do: set_name(module, app_name)
+
+  def set_name(:set_gen_server, module, app_name), do: set_name(module, app_name)
+
+  def set_name(:set_supervisor, module, app_name), do: {:via, module, app_name}
+
+  defp set_name(module, app_name), do: {:via, Registry, {@walex_registry, {module, app_name}}}
+
+  def get_state(:get_agent, module, app_name) do
+    Agent.get({:via, Registry, {:walex_registry, {module, app_name}}}, & &1)
+  end
+end

--- a/test/walex/configs_test.exs
+++ b/test/walex/configs_test.exs
@@ -1,0 +1,99 @@
+defmodule WalEx.ConfigsTest do
+  use ExUnit.Case, async: true
+
+  alias WalEx.Configs
+
+  setup do
+    {:ok, _pid} = WalEx.Registry.start_registry()
+    :ok
+  end
+
+  describe "start_link/2" do
+    test "should start a process" do
+      assert {:ok, pid} = Configs.start_link(configs: get_base_configs())
+
+      assert is_pid(pid)
+    end
+
+    test "should accept database url as config and split it into the right configs" do
+      configs = [
+        name: :test_name,
+        url: "postgres://username:password@hostname:5432/database",
+        subscriptions: ["subscriptions"],
+        publication: "publication",
+        modules: ["modules"]
+      ]
+
+      Configs.start_link(configs: configs)
+
+      assert [
+               hostname: "hostname",
+               username: "username",
+               password: "password",
+               port: 5432,
+               database: "database"
+             ] ==
+               Configs.get_configs(:test_name, [:hostname, :username, :password, :database, :port])
+    end
+  end
+
+  describe "get_configs/2" do
+    setup do
+      {:ok, _pid} = Configs.start_link(configs: get_base_configs())
+      :ok
+    end
+
+    test "should return all configs when second parameter is '[]'" do
+      assert [
+               hostname: "hostname",
+               username: "username",
+               password: "password",
+               port: 5432,
+               database: "database",
+               subscriptions: ["subscriptions"],
+               publication: "publication",
+               modules: ["modules"],
+               name: :test_name
+             ] == Configs.get_configs(:test_name, [])
+    end
+
+    test "should return only selected configs when second parameter is require a filter" do
+      assert [hostname: "hostname", modules: ["modules"]] ==
+               Configs.get_configs(:test_name, [:modules, :hostname])
+    end
+
+    test "should filter configs by process name" do
+      configs =
+        get_base_configs()
+        |> Keyword.replace(:name, :other_name)
+        |> Keyword.replace(:database, "other_database")
+
+      {:ok, _pid} = Configs.start_link(configs: configs)
+
+      assert [database: "database", name: :test_name] ==
+               Configs.get_configs(:test_name, [:database, :name])
+
+      assert [database: "other_database", name: :other_name] ==
+               Configs.get_configs(:other_name, [:database, :name])
+    end
+  end
+
+  defp get_base_configs(keys \\ []) do
+    configs = [
+      name: :test_name,
+      hostname: "hostname",
+      username: "username",
+      password: "password",
+      database: "database",
+      port: 5432,
+      subscriptions: ["subscriptions"],
+      publication: "publication",
+      modules: ["modules"]
+    ]
+
+    case keys do
+      [] -> configs
+      _keys -> Keyword.take(configs, keys)
+    end
+  end
+end

--- a/test/walex/configs_test.exs
+++ b/test/walex/configs_test.exs
@@ -1,5 +1,5 @@
 defmodule WalEx.ConfigsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias WalEx.Configs
 

--- a/test/walex/configs_test.exs
+++ b/test/walex/configs_test.exs
@@ -43,7 +43,7 @@ defmodule WalEx.ConfigsTest do
       :ok
     end
 
-    test "should return all configs when second parameter is '[]'" do
+    test "should return all configs when second parameter is not sent" do
       assert [
                hostname: "hostname",
                username: "username",
@@ -54,7 +54,7 @@ defmodule WalEx.ConfigsTest do
                publication: "publication",
                modules: ["modules"],
                name: :test_name
-             ] == Configs.get_configs(:test_name, [])
+             ] == Configs.get_configs(:test_name)
     end
 
     test "should return only selected configs when second parameter is require a filter" do

--- a/test/walex/registry_test.exs
+++ b/test/walex/registry_test.exs
@@ -1,0 +1,58 @@
+defmodule WalEx.RegistryTest do
+  use ExUnit.Case, async: false
+
+  alias WalEx.Registry, as: WalExRegistry
+
+  describe "start_registry/0" do
+    test "should start a process" do
+      assert {:ok, pid} = WalExRegistry.start_registry()
+
+      assert is_pid(pid)
+    end
+  end
+
+  describe "set_name/3" do
+    setup do
+      assert {:ok, _pid} = WalExRegistry.start_registry()
+      :ok
+    end
+
+    test "should set agent name" do
+      assert {:via, Registry, {:walex_registry, {WalEx.RegistryTest, :app_name_test}}} ==
+               WalExRegistry.set_name(:set_agent, __MODULE__, :app_name_test)
+    end
+
+    test "should set get server name" do
+      assert {:via, Registry, {:walex_registry, {WalEx.RegistryTest, :app_name_test}}} ==
+               WalExRegistry.set_name(:set_gen_server, __MODULE__, :app_name_test)
+    end
+
+    test "should set supervisor name" do
+      assert {:via, WalEx.RegistryTest, :app_name_test} ==
+               WalExRegistry.set_name(:set_supervisor, __MODULE__, :app_name_test)
+    end
+  end
+
+  describe "get_state/3" do
+    setup do
+      assert {:ok, _pid} = WalExRegistry.start_registry()
+      :ok
+    end
+
+    test "should set agent state" do
+      name = WalExRegistry.set_name(:set_agent, __MODULE__, :app_name_test)
+
+      configs = [
+        my_atom: :test_config,
+        my_number: 99,
+        my_string: "test config",
+        my_map: %{john: :doe},
+        my_list: [1, 9, 9, 4]
+      ]
+
+      Agent.start_link(fn -> configs end, name: name)
+
+      assert configs == WalExRegistry.get_state(:get_agent, __MODULE__, :app_name_test)
+    end
+  end
+end

--- a/test/walex/supervisor_test.exs
+++ b/test/walex/supervisor_test.exs
@@ -1,0 +1,59 @@
+defmodule WalEx.SupervisorTest do
+  use ExUnit.Case, async: false
+
+  alias WalEx.Supervisor, as: WalExSupervisor
+
+  describe "start_link/2" do
+    test "should start a process" do
+      assert {:ok, pid} = WalExSupervisor.start_link(get_base_configs())
+
+      assert is_pid(pid)
+    end
+
+    test "should raise if any required config is missing" do
+      assert_raise RuntimeError,
+                   "Following configs are missing: [:hostname, :username, :password, :port, :database, :subscriptions, :publication, :modules, :name]",
+                   fn -> WalExSupervisor.start_link([]) end
+    end
+
+    test "should start multiple supervision trees" do
+      configs_1 = get_base_configs()
+      configs_2 = Keyword.put(configs_1, :name, :other_name)
+      configs_3 = Keyword.put(configs_1, :name, :another_name)
+
+      assert {:ok, pid_1} = WalExSupervisor.start_link(configs_1)
+      assert {:ok, pid_2} = WalExSupervisor.start_link(configs_2)
+      assert {:ok, pid_3} = WalExSupervisor.start_link(configs_3)
+
+      assert is_pid(pid_1)
+      assert is_pid(pid_2)
+      assert is_pid(pid_3)
+    end
+
+    test "should start WalEx.Registry" do
+      assert {:ok, _pid} = WalExSupervisor.start_link(get_base_configs())
+
+      pid = Process.whereis(:walex_registry)
+      assert is_pid(pid)
+    end
+  end
+
+  defp get_base_configs(keys \\ []) do
+    configs = [
+      name: :test_name,
+      hostname: "hostname",
+      username: "username",
+      password: "password",
+      database: "database",
+      port: 5432,
+      subscriptions: ["subscriptions"],
+      publication: "publication",
+      modules: ["modules"]
+    ]
+
+    case keys do
+      [] -> configs
+      _keys -> Keyword.take(configs, keys)
+    end
+  end
+end


### PR DESCRIPTION
Hi!

I made this implementation with the aim of making Walex flexible for multiple configurations. The main use case would be Umbrella Apps, using different configs in each app and even different databases.

I did some tests, and it's working fine.

I also made some code changes following this popular style guide for elixir https://github.com/christopheradams/elixir_style_guide, and some other changes after running credo https://github.com/rrrene/credo on the project.

I know the change ended up changing the library quite a bit, and maybe even a new WalEx 2.0.0 version!? But I believe it can be very useful for several applications.

Please let me know if you find anything you think is wrong.

In the next few days I intend to start implementing tests in the application, and I think it makes sense to add to this PR, so I will ask you to wait any possible merge from this PR until I finished it :)