### PR TITLE
Add SSL Configuration Options

### DIFF
--- a/lib/walex/configs.ex
+++ b/lib/walex/configs.ex
@@ -35,7 +35,9 @@ defmodule WalEx.Configs do
       subscriptions: Keyword.get(configs, :subscriptions),
       publication: Keyword.get(configs, :publication),
       modules: Keyword.get(configs, :modules),
-      name: Keyword.get(configs, :name)
+      name: Keyword.get(configs, :name),
+      ssl: Keyword.get(configs, :ssl, false),
+      ssl_opts: Keyword.get(configs, :ssl_opts, [verify: :verify_none])
     ]
   end
 

--- a/lib/walex/replication_server.ex
+++ b/lib/walex/replication_server.ex
@@ -16,7 +16,7 @@ defmodule WalEx.ReplicationServer do
   end
 
   defp set_pgx_replication_conn_opts(app_name) do
-    database_configs_keys = [:hostname, :username, :password, :port, :database]
+    database_configs_keys = [:hostname, :username, :password, :port, :database, :ssl, :ssl_opts]
 
     extra_opts = [auto_reconnect: true]
     database_configs = WalEx.Configs.get_configs(app_name, database_configs_keys)

--- a/test/walex/configs_test.exs
+++ b/test/walex/configs_test.exs
@@ -31,9 +31,11 @@ defmodule WalEx.ConfigsTest do
                username: "username",
                password: "password",
                port: 5432,
-               database: "database"
+               database: "database",
+               ssl: false,
+               ssl_opts: [verify: :verify_none]
              ] ==
-               Configs.get_configs(:test_name, [:hostname, :username, :password, :database, :port])
+               Configs.get_configs(:test_name, [:hostname, :username, :password, :database, :port, :ssl, :ssl_opts])
     end
   end
 
@@ -53,13 +55,20 @@ defmodule WalEx.ConfigsTest do
                subscriptions: ["subscriptions"],
                publication: "publication",
                modules: ["modules"],
-               name: :test_name
+               name: :test_name,
+               ssl: false,
+               ssl_opts: [verify: :verify_none]
              ] == Configs.get_configs(:test_name)
     end
 
     test "should return only selected configs when second parameter is require a filter" do
-      assert [hostname: "hostname", modules: ["modules"]] ==
-               Configs.get_configs(:test_name, [:modules, :hostname])
+      assert [
+               hostname: "hostname",
+               modules: ["modules"],
+               ssl: false,
+               ssl_opts: [verify: :verify_none]
+             ] ==
+               Configs.get_configs(:test_name, [:modules, :hostname, :ssl, :ssl_opts])
     end
 
     test "should filter configs by process name" do
@@ -70,11 +79,21 @@ defmodule WalEx.ConfigsTest do
 
       {:ok, _pid} = Configs.start_link(configs: configs)
 
-      assert [database: "database", name: :test_name] ==
-               Configs.get_configs(:test_name, [:database, :name])
+      assert [
+               database: "database",
+               name: :test_name,
+               ssl: false,
+               ssl_opts: [verify: :verify_none]
+             ] ==
+               Configs.get_configs(:test_name, [:database, :name, :ssl, :ssl_opts])
 
-      assert [database: "other_database", name: :other_name] ==
-               Configs.get_configs(:other_name, [:database, :name])
+      assert [
+               database: "other_database",
+               name: :other_name,
+               ssl: false,
+               ssl_opts: [verify: :verify_none]
+             ] ==
+               Configs.get_configs(:other_name, [:database, :name, :ssl, :ssl_opts])
     end
   end
 
@@ -88,7 +107,9 @@ defmodule WalEx.ConfigsTest do
       port: 5432,
       subscriptions: ["subscriptions"],
       publication: "publication",
-      modules: ["modules"]
+      modules: ["modules"],
+      ssl: false,
+      ssl_opts: [verify: :verify_none]
     ]
 
     case keys do


### PR DESCRIPTION
This PR introduces SSL configuration options to WalEx modules to support SSL connections for database interactions. The new configuration options include the `ssl` and `ssl_opts` keys which can be specified in the configuration parameters.

### Changes:
1. Added `ssl` and `ssl_opts` keys to the `get_configs` function in the `WalEx.Configs` module.
2. Updated `set_pgx_replication_conn_opts` function in `WalEx.ReplicationServer` module to include `ssl` and `ssl_opts` keys in `database_configs_keys`.
3. Updated `WalEx.ConfigsTest` module to include tests for the newly added configuration options.
4. Updated test cases in `WalEx.ConfigsTest` to reflect the new configuration options.

### Impact:
- These changes allow users to configure SSL settings for database connections, providing enhanced security for data transmission.
- The default behavior (non-SSL) remains unchanged if the SSL options are not provided.

### Testing:
- Updated unit tests to cover the new configuration options and ensure backward compatibility.
