### PR TITLE
Test failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ walex-*.tar
 
 # VSCode
 .vscode/
+
+# ignore .DS_Store files created by macOS
+.DS_Store
+*/.DS_Store

--- a/test/walex/database_test.exs
+++ b/test/walex/database_test.exs
@@ -39,10 +39,10 @@ defmodule WalEx.DatabaseTest do
   def get_configs do
     [
       name: :todos,
-      hostname: "hostname",
-      username: "username",
-      password: "password",
-      database: "todos_test",
+      hostname: "localhost",
+      username: "postgres",
+      password: "postgres",
+      database: @test_database,
       port: 5432,
       subscriptions: ["user", "todo"],
       publication: "events"


### PR DESCRIPTION
get_configs function in database_test.exs provides different DB settings from the ones written in README.
So following the instruction in REAMD fails the database test.
I changed the get_configs function according to the default DB configs.