### PR TITLE
Restart publisher even though an event handler raised an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ walex-*.tar
 
 # VSCode
 .vscode/
+
+# .DS_Store files from macOS
+**/.DS_Store

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -35,10 +35,6 @@ defmodule WalEx.Replication.Server do
   def init(opts) do
     app_name = Keyword.get(opts, :app_name)
 
-    if is_nil(Process.whereis(Publisher)) do
-      {:ok, _pid} = Publisher.start_link([])
-    end
-
     {:ok, %{step: :disconnected, app_name: app_name}}
   end
 

--- a/lib/walex/replication/supervisor.ex
+++ b/lib/walex/replication/supervisor.ex
@@ -4,6 +4,7 @@ defmodule WalEx.Replication.Supervisor do
   use Supervisor
 
   alias WalEx.Replication.Server
+  alias WalEx.Replication.Publisher
 
   def start_link(opts) do
     app_name = Keyword.get(opts, :app_name)
@@ -19,7 +20,10 @@ defmodule WalEx.Replication.Supervisor do
       |> Keyword.get(:configs)
       |> Keyword.get(:app_name)
 
-    children = [{Server, app_name: app_name}]
+    children = [
+      {Publisher, []},
+      {Server, app_name: app_name}
+    ]
 
     Supervisor.init(children, strategy: :one_for_all)
   end

--- a/test/walex/error_test.exs
+++ b/test/walex/error_test.exs
@@ -1,0 +1,87 @@
+defmodule WalEx.ErrorTest do
+  use ExUnit.Case, async: false
+
+  alias WalEx.Supervisor, as: WalExSupervisor
+
+  require Logger
+
+  @test_database "todos_test"
+
+  describe "errors in event handlers" do
+    test "should restart the publisher process" do
+      {:ok, pid} = start_database()
+      configs = get_configs()
+      {:ok, _} = WalExSupervisor.start_link(configs)
+
+      users = """
+        INSERT INTO \"user\" (email, name, age)
+        VALUES
+          ('test.user@example.com', 'Test User', 28);
+      """
+
+      Postgrex.query!(pid, users, [])
+
+      :timer.sleep(1000)
+
+      publisher_pid = Process.whereis(WalEx.Replication.Publisher)
+      assert is_pid(publisher_pid)
+
+      delete_users = """
+        DELETE FROM "user" WHERE email = 'test.user@example.com';
+      """
+
+      Postgrex.query!(pid, delete_users, [])
+
+      :timer.sleep(1000)
+
+      publisher_pid = Process.whereis(WalEx.Replication.Publisher)
+      assert is_pid(publisher_pid)
+    end
+  end
+
+  defp query(pid, query) do
+    pid
+    |> Postgrex.query!(query, [])
+    |> map_rows_to_columns()
+  end
+
+  defp map_rows_to_columns(%Postgrex.Result{columns: columns, rows: rows}) do
+    Enum.map(rows, fn row -> Enum.zip(columns, row) |> Map.new() end)
+  end
+
+  defp start_database() do
+    Postgrex.start_link(
+      hostname: "localhost",
+      username: "postgres",
+      password: "postgres",
+      database: @test_database
+    )
+  end
+
+  defp get_configs(keys \\ []) do
+    configs = [
+      name: :test_name,
+      hostname: "localhost",
+      username: "postgres",
+      password: "postgres",
+      database: @test_database,
+      port: 5432,
+      subscriptions: [:user, :todo],
+      publication: ["events"],
+      modules: [WalEx.TestModule]
+    ]
+
+    case keys do
+      [] -> configs
+      _keys -> Keyword.take(configs, keys)
+    end
+  end
+end
+
+defmodule WalEx.TestModule do
+  use WalEx.Event, name: :test_name
+
+  def process_all(_transaction) do
+    raise "test error"
+  end
+end


### PR DESCRIPTION
- starting publisher in the replication supervisor instead of the server
- adding a test for the error case