### PR TITLE
remove overriding child_spec

### DIFF
--- a/lib/walex/supervisor.ex
+++ b/lib/walex/supervisor.ex
@@ -8,13 +8,6 @@ defmodule WalEx.Supervisor do
   alias WalEx.Replication.Supervisor, as: ReplicationSupervisor
   alias WalExConfig.Registry, as: WalExRegistry
 
-  def child_spec(opts) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, [opts]}
-    }
-  end
-
   def start_link(opts) do
     app_name = Keyword.get(opts, :name)
     module_names = build_module_names(app_name, opts)


### PR DESCRIPTION
We are overriding WalEx supervisor's child_spec without setting ``type`` key 
which makes the type as default ``:worker`` instead of ``:supervisor``
( https://hexdocs.pm/elixir/1.12/Supervisor.html#module-child-specification )

can check it by running
```
MyApp.Supervisor.which_children()
```
shows

```
[
  ...
  {WalEx.Supervisor, #PID<0.617.0>, :worker, [WalEx.Supervisor]},
  ...
]
```

This makes the whole app crash whenever any of the Event modules or other WalEx processes crashes.

we have choices of 
- adding ``type: :supervisor`` 
- removing overriding child_spec

I chose the latter as there is no significant reason to override the child_spec.

