### PR TITLE
Supervisor process foundable with :via option

### DIFF
--- a/lib/walex/config/registry.ex
+++ b/lib/walex/config/registry.ex
@@ -17,7 +17,7 @@ defmodule WalEx.Config.Registry do
 
   def set_name(:set_agent, module, app_name), do: set_name(module, app_name)
   def set_name(:set_gen_server, module, app_name), do: set_name(module, app_name)
-  def set_name(:set_supervisor, module, app_name), do: {:via, module, app_name}
+  def set_name(:set_supervisor, module, app_name), do: set_name(module, app_name)
 
   defp set_name(module, app_name), do: {:via, Registry, {@walex_registry, {module, app_name}}}
 

--- a/lib/walex/destinations/supervisor.ex
+++ b/lib/walex/destinations/supervisor.ex
@@ -8,7 +8,7 @@ defmodule WalEx.Destinations.Supervisor do
   alias Destinations.{EventModules, EventRelay, Webhooks}
 
   def start_link(opts) do
-    app_name = Keyword.get(opts, :app_name)
+    app_name = Keyword.get(opts, :name)
     name = Config.Registry.set_name(:set_supervisor, __MODULE__, app_name)
 
     Supervisor.start_link(__MODULE__, opts, name: name)

--- a/lib/walex/destinations/supervisor.ex
+++ b/lib/walex/destinations/supervisor.ex
@@ -11,14 +11,13 @@ defmodule WalEx.Destinations.Supervisor do
     app_name = Keyword.get(opts, :app_name)
     name = Config.Registry.set_name(:set_supervisor, __MODULE__, app_name)
 
-    Supervisor.start_link(__MODULE__, configs: opts, name: name)
+    Supervisor.start_link(__MODULE__, opts, name: name)
   end
 
   @impl true
   def init(opts) do
     app_name =
       opts
-      |> Keyword.get(:configs)
       |> Keyword.get(:name)
 
     children =

--- a/lib/walex/replication/supervisor.ex
+++ b/lib/walex/replication/supervisor.ex
@@ -9,14 +9,13 @@ defmodule WalEx.Replication.Supervisor do
     app_name = Keyword.get(opts, :app_name)
     name = WalEx.Config.Registry.set_name(:set_supervisor, __MODULE__, app_name)
 
-    Supervisor.start_link(__MODULE__, configs: opts, name: name)
+    Supervisor.start_link(__MODULE__, opts, name: name)
   end
 
   @impl true
   def init(opts) do
     app_name =
       opts
-      |> Keyword.get(:configs)
       |> Keyword.get(:app_name)
 
     children = [

--- a/lib/walex/supervisor.ex
+++ b/lib/walex/supervisor.ex
@@ -19,7 +19,7 @@ defmodule WalEx.Supervisor do
 
     name = WalExRegistry.set_name(:set_supervisor, __MODULE__, app_name)
 
-    Supervisor.start_link(__MODULE__, configs: supervisor_opts, name: name)
+    Supervisor.start_link(__MODULE__, supervisor_opts, name: name)
   end
 
   @impl true
@@ -63,8 +63,7 @@ defmodule WalEx.Supervisor do
     Enum.filter(other_configs, &(not Keyword.has_key?(opts, &1)))
   end
 
-  defp set_children(opts) do
-    configs = Keyword.get(opts, :configs)
+  defp set_children(configs) do
     app_name = Keyword.get(configs, :name)
 
     [

--- a/lib/walex/supervisor.ex
+++ b/lib/walex/supervisor.ex
@@ -8,13 +8,6 @@ defmodule WalEx.Supervisor do
   alias WalEx.Replication.Supervisor, as: ReplicationSupervisor
   alias WalExConfig.Registry, as: WalExRegistry
 
-  def child_spec(opts) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, [opts]}
-    }
-  end
-
   def start_link(opts) do
     app_name = Keyword.get(opts, :name)
     module_names = build_module_names(app_name, opts)

--- a/test/walex/config/registry_test.exs
+++ b/test/walex/config/registry_test.exs
@@ -1,8 +1,22 @@
 defmodule WalEx.Config.RegistryTest do
   use ExUnit.Case, async: false
 
+  require Logger
+
+  alias WalEx.Supervisor, as: WalExSupervisor
   alias WalEx.Config.Registry, as: WalExRegistry
   alias WalEx.Config.RegistryTest, as: WalExRegistryTest
+
+  @base_configs [
+    name: :test_name,
+    hostname: "hostname",
+    username: "username",
+    password: "password",
+    database: "todos_test",
+    port: 5432,
+    subscriptions: ["subscriptions"],
+    publication: "publication"
+  ]
 
   describe "start_registry/0" do
     test "should start a process" do
@@ -28,8 +42,29 @@ defmodule WalEx.Config.RegistryTest do
     end
 
     test "should set supervisor name" do
-      assert {:via, WalExRegistryTest, :app_name_test} ==
+      assert {:via, Registry, {:walex_registry, {WalExRegistryTest, :app_name_test}}} ==
                WalExRegistry.set_name(:set_supervisor, __MODULE__, :app_name_test)
+    end
+
+    test "should be able to find processes" do
+      assert {:ok, walex_supervisor_pid} = WalExSupervisor.start_link(@base_configs)
+
+      assert walex_supervisor_pid ==
+               GenServer.whereis(
+                 WalExRegistry.set_name(:set_supervisor, WalExSupervisor, :test_name)
+               )
+
+      assert GenServer.whereis(
+               WalExRegistry.set_name(:set_gen_server, WalEx.Destinations, :test_name)
+             ) != nil
+
+      assert GenServer.whereis(
+               WalExRegistry.set_name(:set_gen_server, WalEx.Replication.Server, :test_name)
+             ) != nil
+
+      assert GenServer.whereis(
+               WalExRegistry.set_name(:set_gen_server, WalEx.Replication.Publisher, :test_name)
+             ) != nil
     end
   end
 
@@ -46,6 +81,17 @@ defmodule WalEx.Config.RegistryTest do
       Agent.start_link(fn -> configs end, name: name)
 
       assert configs == WalExRegistry.get_state(:get_agent, __MODULE__, :app_name_test)
+    end
+  end
+
+  describe "find_pid" do
+    test "should find Supervisor" do
+      assert {:ok, walex_supervisor_pid} = WalExSupervisor.start_link(@base_configs)
+
+      assert walex_supervisor_pid ==
+               GenServer.whereis(
+                 WalEx.Config.Registry.set_name(:set_supervisor, WalEx.Supervisor, :test_name)
+               )
     end
   end
 end

--- a/test/walex/config/registry_test.exs
+++ b/test/walex/config/registry_test.exs
@@ -55,16 +55,37 @@ defmodule WalEx.Config.RegistryTest do
                )
 
       assert GenServer.whereis(
+               WalExRegistry.set_name(
+                 :set_supervisor,
+                 WalEx.Destinations.Supervisor,
+                 :test_name
+               )
+             )
+             |> is_pid()
+
+      assert GenServer.whereis(
+               WalExRegistry.set_name(
+                 :set_supervisor,
+                 WalEx.Replication.Supervisor,
+                 :test_name
+               )
+             )
+             |> is_pid()
+
+      assert GenServer.whereis(
                WalExRegistry.set_name(:set_gen_server, WalEx.Destinations, :test_name)
-             ) != nil
+             )
+             |> is_pid()
 
       assert GenServer.whereis(
                WalExRegistry.set_name(:set_gen_server, WalEx.Replication.Server, :test_name)
-             ) != nil
+             )
+             |> is_pid()
 
       assert GenServer.whereis(
                WalExRegistry.set_name(:set_gen_server, WalEx.Replication.Publisher, :test_name)
-             ) != nil
+             )
+             |> is_pid()
     end
   end
 


### PR DESCRIPTION
(This PR is stacked with the previous one)

The current implementation of WalEx.Config.Registry
```
  def set_name(:set_supervisor, module, app_name), do: {:via, module, app_name}
```

makes the supervisor process can’t be found with ``GenServer.whereis`` 
as WalEx.Supervisor is not implementing Registry behavior

test:

```
      assert {:ok, walex_supervisor_pid} = WalExSupervisor.start_link(@base_configs)

      assert walex_supervisor_pid ==
               GenServer.whereis(
                 WalExRegistry.set_name(:set_supervisor, WalExSupervisor, :test_name)
               )
```
produces the error

```
** (UndefinedFunctionError) function WalEx.Supervisor.whereis_name/1 is undefined or private
    (walex 3.7.0) WalEx.Supervisor.whereis_name(Sendman)
    (elixir 1.16.0) lib/gen_server.ex:1286: GenServer.whereis/1
    (elixir 1.16.0) lib/gen_server.ex:1059: GenServer.stop/3
```

So I changed the WalEx.Config.Registry to use
```
  def set_name(:set_supervisor, module, app_name), do: set_name(module, app_name)
```
like other modules


also,
```
    Supervisor.start_link(__MODULE__, configs: supervisor_opts, name: name)
```
doesn’t properly register the process name (it is using start_link/2)
We can check this with the test case above.

So I changed to use start_link/3

    Supervisor.start_link(__MODULE__, supervisor_opts, name: name)

With this change, each Supervisor is starting with the name attached and also foundable with its name 