### PR TITLE
feat: pass socket_options to Postgrex

### DIFF
--- a/lib/walex/config/config.ex
+++ b/lib/walex/config/config.ex
@@ -118,6 +118,7 @@ defmodule WalEx.Config do
       database: Keyword.get(configs, :database, db_configs_from_url[:database]),
       ssl: Keyword.get(configs, :ssl, false),
       ssl_opts: Keyword.get(configs, :ssl_opts, verify: :verify_none),
+      socket_options: Keyword.get(configs, :socket_options, []),
       subscriptions: subscriptions,
       publication: Keyword.get(configs, :publication),
       destinations: Keyword.put(destinations, :modules, module_names),

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -13,7 +13,7 @@ defmodule WalEx.Replication.Server do
 
   def start_link(opts) do
     app_name = Keyword.get(opts, :app_name)
-    opts = set_pgx_replication_conn_opts(app_name) |> IO.inspect
+    opts = set_pgx_replication_conn_opts(app_name)
 
     Postgrex.ReplicationConnection.start_link(__MODULE__, [app_name: app_name], opts)
   end

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -13,13 +13,13 @@ defmodule WalEx.Replication.Server do
 
   def start_link(opts) do
     app_name = Keyword.get(opts, :app_name)
-    opts = set_pgx_replication_conn_opts(app_name)
+    opts = set_pgx_replication_conn_opts(app_name) |> IO.inspect
 
     Postgrex.ReplicationConnection.start_link(__MODULE__, [app_name: app_name], opts)
   end
 
   defp set_pgx_replication_conn_opts(app_name) do
-    database_configs_keys = [:hostname, :username, :password, :port, :database, :ssl, :ssl_opts]
+    database_configs_keys = [:hostname, :username, :password, :port, :database, :ssl, :ssl_opts, :socket_options]
     extra_opts = [auto_reconnect: true]
     database_configs = WalEx.Config.get_configs(app_name, database_configs_keys)
 

--- a/test/walex/config/config_test.exs
+++ b/test/walex/config/config_test.exs
@@ -19,6 +19,7 @@ defmodule WalEx.ConfigTest do
     port: 5432,
     ssl: false,
     ssl_opts: [verify: :verify_none],
+    socket_options: [],
     subscriptions: ["subscriptions"],
     publication: "publication",
     destinations: [modules: [MyApp.CustomModule]]


### PR DESCRIPTION
I've deployed a system using WalEx to fly.io. I can only connect to the postgres database over IPv6, which required this change. Wanted to offer it back -- thanks for the library!

In general, it could make sense to accept all of the Postgrex configuration options as part of the WalEx config, but this is all I needed and I didn't want to over-complicate things.