### PR TITLE
pg_restart: handle case of using docker-compose.dbs.yaml

### DIFF
--- a/lib/mix/tasks/helpers.ex
+++ b/lib/mix/tasks/helpers.ex
@@ -1,4 +1,11 @@
 defmodule Mix.Tasks.Walex.Helpers do
+  @config %{
+    hostname: "localhost",
+    username: "postgres",
+    password: "postgres",
+    port: 5432
+  }
+
   @moduledoc false
   def create_database(database_name) do
     "-c \"CREATE DATABASE #{database_name};\""
@@ -17,9 +24,16 @@ defmodule Mix.Tasks.Walex.Helpers do
   end
 
   def database_cmd(cmd) do
-    db_cmd = "psql -U postgres " <> cmd
+    db_cmd = "psql " <> cmd
 
-    case System.shell(db_cmd) do
+    env = [
+      {"PGHOST", @config.hostname},
+      {"PGUSER", @config.username},
+      {"PGPASSWORD", @config.password},
+      {"PGPORT", Integer.to_string(@config.port)}
+    ]
+
+    case System.shell(db_cmd, env: env) do
       {output, 0} ->
         output
 


### PR DESCRIPTION
database_test fails early if postgres was setup using the docker-compose.dbs.yaml of the repo, handle this case

can saddly be somewhat flacky with the following error if the restart takes too long:
```
     ** (DBConnection.ConnectionError) connection not available and request was dropped from queue after 2147ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:

       1. Ensuring your database is available and that you can connect to it
       2. Tracking down slow queries and making sure they are running fast enough
       3. Increasing the pool_size (although this increases resource consumption)
       4. Allowing requests to wait longer by increasing :queue_target and :queue_interval

     See DBConnection.start_link/2 for more information
```

also fixed lib/mix/tasks/helpers.ex when using the docker compose