### PR TITLE
add transaction's final_lsn in each event

### DIFF
--- a/lib/walex/changes.ex
+++ b/lib/walex/changes.ex
@@ -9,7 +9,7 @@ defmodule WalEx.Changes do
   defmodule(Transaction, do: defstruct([:changes, :commit_timestamp]))
 
   defmodule(NewRecord,
-    do: defstruct([:type, :record, :schema, :table, :columns, :commit_timestamp])
+    do: defstruct([:type, :record, :schema, :table, :columns, :commit_timestamp, :lsn])
   )
 
   defmodule(UpdatedRecord,
@@ -21,12 +21,13 @@ defmodule WalEx.Changes do
         :schema,
         :table,
         :columns,
-        :commit_timestamp
+        :commit_timestamp,
+        :lsn
       ])
   )
 
   defmodule(DeletedRecord,
-    do: defstruct([:type, :old_record, :schema, :table, :columns, :commit_timestamp])
+    do: defstruct([:type, :old_record, :schema, :table, :columns, :commit_timestamp, :lsn])
   )
 
   defmodule(TruncatedRelation, do: defstruct([:type, :schema, :table, :commit_timestamp]))

--- a/lib/walex/replication/publisher.ex
+++ b/lib/walex/replication/publisher.ex
@@ -116,7 +116,8 @@ defmodule WalEx.Replication.Publisher do
           table: name,
           columns: columns,
           record: data,
-          commit_timestamp: commit_timestamp
+          commit_timestamp: commit_timestamp,
+          lsn: lsn
         }
 
         updated_state = %State{
@@ -158,7 +159,8 @@ defmodule WalEx.Replication.Publisher do
           columns: columns,
           old_record: old_data,
           record: data,
-          commit_timestamp: commit_timestamp
+          commit_timestamp: commit_timestamp,
+          lsn: lsn
         }
 
         updated_state = %State{
@@ -198,7 +200,8 @@ defmodule WalEx.Replication.Publisher do
           table: name,
           columns: columns,
           old_record: data,
-          commit_timestamp: commit_timestamp
+          commit_timestamp: commit_timestamp,
+          lsn: lsn
         }
 
         updated_state = %State{


### PR DESCRIPTION
In the cases where avoiding re-processing of events is mandatory
the consumer will need to have access to the LSN of the current transaction

For instance using a redis lock with an expire to avoid multiple workers to process the same event
or storing the latest LSN when a transaction is finished processing to know where the consumer shoud resume if it gets restarted (XXX/XXX start location in START_REPLICATION_SLOT)