### PR TITLE
Durable slot

### DIFF
--- a/lib/walex/config/config.ex
+++ b/lib/walex/config/config.ex
@@ -6,7 +6,7 @@ defmodule WalEx.Config do
 
   alias WalEx.Config.Registry, as: WalExRegistry
 
-  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name)a
+  @allowed_config_value ~w(database hostname name password port publication username webhook_signing_secret slot_name durable_slot)a
   @allowed_config_values ~w(destinations event_relay modules subscriptions)a
 
   def start_link(opts) do
@@ -126,7 +126,8 @@ defmodule WalEx.Config do
       destinations: Keyword.put(destinations, :modules, module_names),
       webhook_signing_secret: Keyword.get(configs, :webhook_signing_secret),
       event_relay: Keyword.get(configs, :event_relay),
-      slot_name: Keyword.get(configs, :slot_name) |> parse_slot_name(name)
+      slot_name: Keyword.get(configs, :slot_name) |> parse_slot_name(name),
+      durable_slot: Keyword.get(configs, :durable_slot, false) == true
     ]
   end
 

--- a/lib/walex/replication/query_builder.ex
+++ b/lib/walex/replication/query_builder.ex
@@ -3,8 +3,16 @@ defmodule WalEx.Replication.QueryBuilder do
     "SELECT 1 FROM pg_publication WHERE pubname = '#{state.publication}' LIMIT 1;"
   end
 
+  def slot_exists(state) do
+    "SELECT active FROM pg_replication_slots WHERE slot_name = '#{state.slot_name}' LIMIT 1;"
+  end
+
   def create_temporary_slot(state) do
     "CREATE_REPLICATION_SLOT #{state.slot_name} TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT;"
+  end
+
+  def create_durable_slot(state) do
+    "CREATE_REPLICATION_SLOT #{state.slot_name} LOGICAL pgoutput NOEXPORT_SNAPSHOT;"
   end
 
   def start_replication_slot(state) do

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -45,17 +45,23 @@ defmodule WalEx.Replication.Server do
   def init(opts) do
     app_name = Keyword.get(opts, :app_name)
 
-    [slot_name: slot_name, publication: publication] =
+    [
+      slot_name: slot_name,
+      publication: publication,
+      durable_slot: durable_slot
+    ] =
       WalEx.Config.get_configs(app_name, [
         :slot_name,
-        :publication
+        :publication,
+        :durable_slot
       ])
 
     state = %{
       step: :disconnected,
       app_name: app_name,
       slot_name: slot_name,
-      publication: publication
+      publication: publication,
+      durable_slot: durable_slot
     }
 
     {:ok, state}
@@ -69,8 +75,13 @@ defmodule WalEx.Replication.Server do
 
   @impl true
   def handle_result([%Postgrex.Result{num_rows: 1}], state = %{step: :publication_exists}) do
-    query = QueryBuilder.create_temporary_slot(state)
-    {:query, query, %{state | step: :create_slot}}
+    if state.durable_slot do
+      query = QueryBuilder.slot_exists(state)
+      {:query, query, %{state | step: :slot_exists}}
+    else
+      query = QueryBuilder.create_temporary_slot(state)
+      {:query, query, %{state | step: :create_slot}}
+    end
   end
 
   @impl true
@@ -79,9 +90,41 @@ defmodule WalEx.Replication.Server do
   end
 
   @impl true
+  def handle_result([%Postgrex.Result{num_rows: 0}], state = %{step: :slot_exists}) do
+    query = QueryBuilder.create_durable_slot(state)
+    {:query, query, %{state | step: :create_slot}}
+  end
+
+  @impl true
+  def handle_result(
+        [%Postgrex.Result{columns: ["active"], rows: [[active]]}],
+        state = %{step: :slot_exists}
+      ) do
+    case active do
+      "f" ->
+        query = QueryBuilder.start_replication_slot(state)
+        {:stream, query, [], %{state | step: :streaming}}
+
+      "t" ->
+        raise "Durable slot already active"
+    end
+  end
+
+  @impl true
+  def handle_result(results, %{step: :slot_exists}) do
+    raise "Failed to check if durable slot already exists. #{inspect(results)}"
+  end
+
+  @impl true
   def handle_result([%Postgrex.Result{} | _results], state = %{step: :create_slot}) do
     query = QueryBuilder.start_replication_slot(state)
     {:stream, query, [], %{state | step: :streaming}}
+  end
+
+  @impl true
+  def handle_result(%Postgrex.Error{} = error, %{step: :create_slot}) do
+    # if durable slot, can happen if multiple instances try to create the same slot
+    raise "Failed to create replication slot, #{inspect(error)}"
   end
 
   @impl true

--- a/lib/walex/replication/server.ex
+++ b/lib/walex/replication/server.ex
@@ -85,8 +85,14 @@ defmodule WalEx.Replication.Server do
   end
 
   @impl true
-  def handle_result(results, %{step: :publication_exists}) do
-    raise "Publication does not exist. #{inspect(results)}"
+  def handle_result(results, %{step: :publication_exists} = state) do
+    case results do
+      [%Postgrex.Result{num_rows: 0}] ->
+        raise "Publication doesn't exists. publication: #{inspect(state.publication)}"
+
+      _ ->
+        raise "Unexpected result when checking if publication exists. #{inspect(results)}"
+    end
   end
 
   @impl true

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -64,9 +64,16 @@ defmodule WalEx.Support.TestHelpers do
 
   def pg_replication_slots(database_pid) do
     pg_replication_slots_query =
-      "SELECT slot_name, slot_type, active FROM \"pg_replication_slots\";"
+      "SELECT slot_name, slot_type, active, temporary FROM \"pg_replication_slots\";"
 
     query(database_pid, pg_replication_slots_query)
+  end
+
+  def pg_drop_slots(database_pid) do
+    pg_drop_slots_query =
+      "SELECT pg_drop_replication_slot(slot_name) FROM \"pg_replication_slots\";"
+
+    query(database_pid, pg_drop_slots_query)
   end
 
   def update_user(database_pid) do

--- a/test/walex/config/config_test.exs
+++ b/test/walex/config/config_test.exs
@@ -92,7 +92,8 @@ defmodule WalEx.ConfigTest do
                destinations: [modules: [MyApp.CustomModule]],
                webhook_signing_secret: nil,
                event_relay: nil,
-               slot_name: "my_app_walex"
+               slot_name: "my_app_walex",
+               durable_slot: false
              ] == Config.get_configs(@app_name)
     end
   end

--- a/test/walex/database_test.exs
+++ b/test/walex/database_test.exs
@@ -27,6 +27,7 @@ defmodule WalEx.DatabaseTest do
   describe "logical replication" do
     setup do
       {:ok, database_pid} = start_database()
+      pg_drop_slots(database_pid)
 
       %{database_pid: database_pid}
     end
@@ -49,7 +50,7 @@ defmodule WalEx.DatabaseTest do
     test "should start replication slot", %{database_pid: database_pid} do
       assert {:ok, replication_pid} = WalExSupervisor.start_link(@base_configs)
       assert is_pid(replication_pid)
-      assert [@replication_slot | _replication_slots] = pg_replication_slots(database_pid)
+      assert [@replication_slot] = pg_replication_slots(database_pid)
     end
 
     test "user-defined slot_name", %{database_pid: database_pid} do
@@ -60,7 +61,7 @@ defmodule WalEx.DatabaseTest do
       assert {:ok, replication_pid} = WalExSupervisor.start_link(config)
 
       assert is_pid(replication_pid)
-      assert [slot | _replication_slots] = pg_replication_slots(database_pid)
+      assert [slot] = pg_replication_slots(database_pid)
       assert Map.fetch!(slot, "slot_name") == slot_name
     end
 
@@ -69,7 +70,7 @@ defmodule WalEx.DatabaseTest do
       database_pid = get_database_pid(supervisor_pid)
 
       assert is_pid(database_pid)
-      assert [@replication_slot | _replication_slots] = pg_replication_slots(database_pid)
+      assert [@replication_slot] = pg_replication_slots(database_pid)
 
       assert Process.exit(database_pid, :kill)
              |> tap_debug("Forcefully killed database connection: ")


### PR DESCRIPTION
adds support for non-temporary replication slots

- adds the optional config toggle durable_slot
- when enabled it will:
  - check if slot already exists
  - try to create it if it doesn't
  - starts it
- the startup will fail if:
  -  the slot already exists and is still active
  - multiple processes/nodes try to:
    -  create the same durable slot around the same time (only one will succeed)
    - start the durable slot at the same time

When the slot is restarted, it will start back at the last wal_end+1 that walex returned in the keep-alive reply to postgres.
Transactions processed between the last keep-alive and the interruption of walex will be replayed.

If event reply is problematic, the end-user must implement a way to mark LSN/transactions as processed to avoid re-processing.

Also event loss is possible currently in this situation:
- Walex receives transaction
- start processing asynchronously 
- receives keep-alive request
- reply with the received wal_end+1 (which is greater than current transaction being processed)
- walex crashes / get interrupted before finishing processing the transaction
- restarts at position wal_end+1 (event was lost)

we made another PR to address this and will submit it shortly

