### PR TITLE
Small tweaks

### DIFF
--- a/lib/walex/config/registry.ex
+++ b/lib/walex/config/registry.ex
@@ -5,6 +5,10 @@ defmodule WalEx.Config.Registry do
 
   @walex_registry :walex_registry
 
+  def child_spec() do
+    {Registry, keys: :unique, name: @walex_registry}
+  end
+
   def start_registry do
     case Process.whereis(@walex_registry) do
       nil ->

--- a/lib/walex/replication/publisher.ex
+++ b/lib/walex/replication/publisher.ex
@@ -67,9 +67,6 @@ defmodule WalEx.Replication.Publisher do
       )
       when commit_lsn == current_txn_lsn do
     Destinations.process(txn, app_name)
-
-    %{state | transaction: nil}
-
     {:noreply, state}
   end
 

--- a/lib/walex/supervisor.ex
+++ b/lib/walex/supervisor.ex
@@ -68,8 +68,8 @@ defmodule WalEx.Supervisor do
 
     [
       {WalExConfig, configs: configs},
-      {ReplicationSupervisor, app_name: app_name},
-      {DestinationsSupervisor, configs}
+      {DestinationsSupervisor, configs},
+      {ReplicationSupervisor, app_name: app_name}
     ]
   end
 end

--- a/test/walex/database_test.exs
+++ b/test/walex/database_test.exs
@@ -221,7 +221,7 @@ defmodule WalEx.DatabaseTest do
   end
 
   def pg_restart(:docker) do
-    case(System.shell("docker compose -f docker-compose.dbs.yml restart db")) do
+    case(System.shell("docker compose -f docker-compose.dbs.yml restart db -t 2")) do
       {_, 0} ->
         :ok
 


### PR DESCRIPTION
small PR with some tweaks / fixes

The main one would be 3123c3f9f6d289c8768d3df8b77ca75dccd608b2
In WalEx.Supervisor, it inverses the order of Replication and Destination in the supervisor tree.
We had to as, without this, this error occurs quite often when the app shutsdown:
```
ErlangError: ** (ErlangError) Erlang error: {:noproc, {GenServer, :call, [{:via, Registry, {:walex_registry, {WalEx.Destinations, App}}}, {:process, %WalEx.Changes.Transaction{changes: [], commit_timestamp: ~U[2024-05-17 13:57:59.109094Z]}, App}, :infinity]}}
lib/gen_server.ex:1103 in GenServer.call/3
lib/walex/replication/publisher.ex:69 in WalEx.Replication.Publisher.handle_cast/2
gen_server.erl:1121 in :gen_server.try_handle_cast/3
gen_server.erl:1183 in :gen_server.handle_msg/6
```
As the Replication `casts` to `Destination` the first Supervisor to start and stop should be Replication.

Another change is e3ae63dacb9d440176c5e0da7013f5d892240be7 that adds a `child_spec` function to WalEx.Config.Registry so that the end user can add the registry to his own Supervisor tree if need be.