### PR TITLE
fix Replication.Supervisor's strategoy and minimal durable-slot/back-pressure documentation in README

### DIFF
--- a/lib/walex/replication/supervisor.ex
+++ b/lib/walex/replication/supervisor.ex
@@ -23,6 +23,21 @@ defmodule WalEx.Replication.Supervisor do
       {Server, app_name: app_name}
     ]
 
-    Supervisor.init(children, strategy: :one_for_one, max_restarts: 10)
+    # one_for_all (or rest_for_one) is required here, reason being:
+    #
+    # if Publisher crashes:
+    #   We lost the current state.
+    #   This means that until Postgres decides to send us all the needed Relations and Types messages again,
+    #   we won't be able to decode any events from the Server.
+    #   In the mid time everything would look ok but all events would get discarded.
+    #   The only way to guarantee to get those back is to restart the Server.
+
+    # if Server crashes:
+    #   The replication will restart at restart_lsn.
+    #   All events from then to the LSN at which the Server crashed will get replayed.
+    #   The means that the message inbox of the Publisher will become potentially inconsistent
+    #   and will likely contain duplicate messages.
+    #   If this is undesirable, one_for_all is required otherwise rest_for_one is fine.
+    Supervisor.init(children, strategy: :one_for_all, max_restarts: 10)
   end
 end


### PR DESCRIPTION
This PR fixes the supervision strategy of `Replication.Supervisor`.
We had an issue in production where we lost all events for multiple hours because the 
Replication.Publisher crashed, restarted and discarded all events until we forced a full restart.
This is actually expect as Postgres only sends the Relations/Types/etc. messages when the replication connection
is started or on an alter on a specific table.
To fix this instead we changed the replication strategy from `one_for_all` to `one_for_one`.

Also update of the README to explain minimally the `durable_slot` and `message_middleware` configuration options.

