### PR TITLE
Fix postgresql array types parsing

### DIFF
--- a/lib/mix/tasks/walex.setup.ex
+++ b/lib/mix/tasks/walex.setup.ex
@@ -102,6 +102,9 @@ defmodule Mix.Tasks.Walex.Setup do
         email citext UNIQUE NOT NULL,
         name VARCHAR  NOT NULL,
         age INTEGER DEFAULT 0,
+        books VARCHAR[] DEFAULT '{}'::VARCHAR[],
+        favorite_numbers INTEGER[] DEFAULT '{}'::INTEGER[],
+        meta JSONB DEFAULT '{}'::JSONB,
         created_at TIMESTAMPTZ DEFAULT NOW(),
         updated_at TIMESTAMPTZ DEFAULT NOW()
       );

--- a/lib/walex/types.ex
+++ b/lib/walex/types.ex
@@ -57,6 +57,34 @@ defmodule WalEx.Types do
     end
   end
 
+  def cast_record(<<123>> <> record, <<"_int", _::binary>>) when is_binary(record) do
+    record
+    |> String.replace_suffix("}", "")
+    |> String.split(",")
+    |> Enum.map(&String.to_integer/1)
+  end
+
+  def cast_record(<<123>> <> record, <<"_float", _::binary>>) when is_binary(record) do
+    record
+    |> String.replace_suffix("}", "")
+    |> String.split(",")
+    |> Enum.map(&String.to_float/1)
+  end
+
+  def cast_record(<<123>> <> record, column_type)
+      when is_binary(record) and column_type in ["_text", "_varchar"] do
+    # Handle quoted strings that may contain commas
+    # Split by commas but handle quoted strings properly
+    record
+    |> String.replace_suffix("}", "")
+    |> String.split(~r/,(?=(?:[^"]*"[^"]*")*[^"]*$)/)
+    |> Enum.map(fn element ->
+      element
+      |> String.trim()
+      |> String.trim("\"")
+    end)
+  end
+
   # TODO: Add additional type castings and ability to load external types
   def cast_record(record, _column_type) do
     record

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -78,7 +78,7 @@ defmodule WalEx.Support.TestHelpers do
 
   def update_user(database_pid) do
     update_user = """
-      UPDATE \"user\" SET age = 30 WHERE id = 1
+      UPDATE \"user\" SET age = 30, books = ARRAY['book1, 2 and 3', 'book4'], favorite_numbers = ARRAY[1, 2, 3], meta = '{"key": {"foo": "bar"}, "list": [1, 2, 3]}'::JSONB WHERE id = 1
     """
 
     Postgrex.query!(database_pid, update_user, [])

--- a/test/walex/event/event_test.exs
+++ b/test/walex/event/event_test.exs
@@ -70,6 +70,12 @@ defmodule WalEx.EventTest do
                    age: 30,
                    created_at: _created_at,
                    email: "john.doe@example.com",
+                   books: ["book1, 2 and 3", "book4"],
+                   favorite_numbers: [1, 2, 3],
+                   meta: %{
+                     "key" => %{"foo" => "bar"},
+                     "list" => [1, 2, 3]
+                   },
                    updated_at: _updated_at
                  },
                  schema: "public",


### PR DESCRIPTION
When I use an array field in PostgreSQL I receive records as strings like this: `{1,2,3}` instead of Elixir arrays.

This PR aims to cast correctly float, integer and string arrays (handling quoted strings and unquoted strings).