### PR TITLE
Allow subscribing to all_tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ config :my_app, WalEx,
   name: MyApp
 ```
 
+If you would like to subscribe to all tables, you can pass a special atom to subscriptions.
+
+```elixir
+config :my_app, WalEx,
+  url: "postgres://username:password@hostname:port/database",
+  publication: "events",
+  subscriptions: [:all_tables],
+  name: MyApp,
+```
+
 You can also dynamically update the config at runtime:
 
 ```elixir

--- a/lib/walex/casting/types.ex
+++ b/lib/walex/casting/types.ex
@@ -135,7 +135,7 @@ defmodule WalEx.Casting.Types do
     # PostgreSQL bytea hex format starts with \x
     if String.starts_with?(record, "\\x") do
       record
-      |> String.slice(2..-1)
+      |> String.slice(2..-1//1)
       |> Base.decode16!(case: :mixed)
     else
       record
@@ -413,7 +413,7 @@ defmodule WalEx.Casting.Types do
           elem ->
             if String.starts_with?(elem, "\\x") do
               elem
-              |> String.slice(2..-1)
+              |> String.slice(2..-1//1)
               |> Base.decode16!(case: :mixed)
             else
               elem

--- a/lib/walex/transaction_filter.ex
+++ b/lib/walex/transaction_filter.ex
@@ -157,7 +157,7 @@ defmodule WalEx.TransactionFilter do
   def subscribes?(%{table: table}, app_name) do
     subscriptions = WalEx.Config.get_configs(app_name, :subscriptions)
 
-    table in subscriptions
+    :all_tables in subscriptions || table in subscriptions
   end
 
   def has_table?(%{table: table}, table_name) when is_atom(table), do: table == table_name


### PR DESCRIPTION
This adds a small feature to allow subscribing to `:all_tables`.

Thanks for this great library @cpursley!