### PR TITLE
deps: allow any postgrex >= 0.20

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule WalEx.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:postgrex, "~> 0.20.0"},
+      {:postgrex, ">= 0.20.0"},
       {:decimal, "~> 2.3.0"},
       {:jason, "~> 1.4"},
       {:timex, "~> 3.7"},


### PR DESCRIPTION
currently prevents users from upgrading to newer versions. latest version of postgrex is 0.22