### PR TITLE
fix: replace Timex with native timestamp casting

### DIFF
--- a/lib/walex/casting/types.ex
+++ b/lib/walex/casting/types.ex
@@ -69,17 +69,18 @@ defmodule WalEx.Casting.Types do
   def cast_record(record, "decimal"), do: cast_record(record, "numeric")
 
   def cast_record(record, "timestamp") when is_binary(record) do
-    with {:ok, %NaiveDateTime{} = naive_date_time} <- Timex.parse(record, "{RFC3339}"),
-         %DateTime{} = date_time <- Timex.to_datetime(naive_date_time) do
-      date_time
-    else
-      _ -> record
+    case NaiveDateTime.from_iso8601(record) do
+      {:ok, %NaiveDateTime{} = naive} ->
+        DateTime.from_naive!(naive, "Etc/UTC")
+
+      _ ->
+        record
     end
   end
 
   def cast_record(record, "timestamptz") when is_binary(record) do
-    case Timex.parse(record, "{RFC3339}") do
-      {:ok, %DateTime{} = date_time} ->
+    case DateTime.from_iso8601(record) do
+      {:ok, %DateTime{} = date_time, _offset} ->
         date_time
 
       _ ->
@@ -258,8 +259,8 @@ defmodule WalEx.Casting.Types do
             nil
 
           elem ->
-            case Timex.parse(elem, "{RFC3339}") do
-              {:ok, %DateTime{} = dt} -> dt
+            case DateTime.from_iso8601(elem) do
+              {:ok, %DateTime{} = dt, _offset} -> dt
               _ -> elem
             end
         end)
@@ -278,11 +279,12 @@ defmodule WalEx.Casting.Types do
             nil
 
           elem ->
-            with {:ok, %NaiveDateTime{} = naive} <- Timex.parse(elem, "{RFC3339}"),
-                 %DateTime{} = dt <- Timex.to_datetime(naive) do
-              dt
-            else
-              _ -> elem
+            case NaiveDateTime.from_iso8601(elem) do
+              {:ok, %NaiveDateTime{} = naive} ->
+                DateTime.from_naive!(naive, "Etc/UTC")
+
+              _ ->
+                elem
             end
         end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,6 @@ defmodule WalEx.MixProject do
       {:postgrex, ">= 0.20.0"},
       {:decimal, "~> 2.3.0"},
       {:jason, "~> 1.4"},
-      {:timex, "~> 3.7.13"},
 
       # Dev & Test
       {:ex_doc, "~> 0.40", only: :dev, runtime: false},

--- a/test/walex/casting/types_test.exs
+++ b/test/walex/casting/types_test.exs
@@ -63,7 +63,7 @@ defmodule WalEx.Casting.TypesTest do
 
   describe "timestamp casting" do
     test "casts timestamp" do
-      result = Types.cast_record("2024-01-15T10:30:00", "timestamp")
+      result = Types.cast_record("2024-01-15 10:30:00.123456", "timestamp")
       assert %DateTime{} = result
       assert result.year == 2024
       assert result.month == 1
@@ -71,7 +71,7 @@ defmodule WalEx.Casting.TypesTest do
     end
 
     test "casts timestamptz" do
-      result = Types.cast_record("2024-01-15T10:30:00Z", "timestamptz")
+      result = Types.cast_record("2024-01-15 10:30:00.123456+00", "timestamptz")
       assert %DateTime{} = result
       assert result.year == 2024
       assert result.time_zone == "Etc/UTC"
@@ -240,7 +240,10 @@ defmodule WalEx.Casting.TypesTest do
   describe "timestamp array casting" do
     test "casts timestamptz arrays" do
       result =
-        Types.cast_record(~s({\"2024-01-15T10:30:00Z\",\"2024-01-16T11:45:00Z\"}), "_timestamptz")
+        Types.cast_record(
+          ~s({"2024-01-15 10:30:00.123+00","2024-01-16 11:45:00.456+00"}),
+          "_timestamptz"
+        )
 
       assert [dt1, dt2] = result
       assert %DateTime{} = dt1


### PR DESCRIPTION
`Timex.parse(record, "{RFC3339}")` requires a `T` separator between date and time, but Postgres WAL `pgoutput` sends timestamps in space-separated format (e.g. `2024-01-15 10:30:00.123456+00`).

This meant timestamp and timestamptz columns were never actually cast to DateTime. Native casting is also significantly faster and more memory efficient.